### PR TITLE
Allow disabling default pages generation

### DIFF
--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = (themeOptions) => {
-  const loadDefaultPages = themeOptions.loadDefaultPages ? themeOptions.loadDefaultPages : true;
+  const loadDefaultPages = themeOptions.loadDefaultPages !== undefined ? themeOptions.loadDefaultPages : true;
   const contentPath      = themeOptions.contentPath || 'content';
   const manifest         = themeOptions.manifest ? themeOptions.manifest : {
     name: `nehalem - A Gatsby theme`,
@@ -192,6 +192,6 @@ module.exports = (themeOptions) => {
           ]
         }
       }
-    ]
+    ].filter(Boolean)
   };
 };


### PR DESCRIPTION
Hi! I'm creating my blog using your theme, and it's really cool! 
However, I've found one bug 😉Here's the fix.

---
In this PR I added the possibility to pass falsy values for `loadDefaultPages`.
Previously [line 2](https://github.com/nehalist/gatsby-theme-nehalem/blob/master/theme/gatsby-config.js#L2) in `gatsby-config.js` didn't work and accepted only truthy values, thus it wasn't possible to disable default pages generation.

I changed it to:
```ts
const loadDefaultPages = themeOptions.loadDefaultPages !== undefined ? themeOptions.loadDefaultPages : true;
```
And I also filtered the plugins list for truthy values.

