### PR TITLE
Update field for UpdatedAt in SEO metadata

### DIFF
--- a/theme/src/components/seo/index.tsx
+++ b/theme/src/components/seo/index.tsx
@@ -149,7 +149,7 @@ const SEO: FunctionComponent<SEOProps> = ({
           "headline": "${siteTitle}",
           "url": "${canonical}",
           ${publishedAt ? `"datePublished": "${publishedAt}",` : ``}
-          ${updatedAt ? `"datePublished": "${updatedAt}",` : ``}
+          ${updatedAt ? `"dateModified": "${updatedAt}",` : ``}
           ${metaImage ? `"image": {
             "@type": "ImageObject",
             "url": "${metaImage}",


### PR DESCRIPTION
I'm using your theme which is really great. Thank you for sharing!

I have discovered a small error reported by the Google Search Console when you have both the PublishedAt and UpdatedAt fields defined. I suspect it is just a typo but you might have encountered other situations that would explain why you've written it that way. Anyway, I propose the fix attached.