### PR TITLE
Fix hidden Table of Contents overlay blocking post

### DIFF
--- a/theme/src/templates/post.tsx
+++ b/theme/src/templates/post.tsx
@@ -36,7 +36,7 @@ const LeftSidebar = styled.div<{ show?: boolean }>`
   @media (max-width: ${Theme.breakpoints.xl}) {
     position: fixed;
     opacity: ${props => props.show ? 1 : 0};
-    z-index: 1000;
+    z-index: ${props => props.show ? 1000 : -1};
     background-color: #fff;
     width: 100% !important;
     max-width: 100%;

--- a/theme/src/templates/post.tsx
+++ b/theme/src/templates/post.tsx
@@ -31,7 +31,7 @@ const PostContainer = styled(Container)`
 const LeftSidebar = styled.div<{ show?: boolean }>`
   min-width: 255px;
   max-width: 225px;
-  transition: opacity .5s;
+  transition: opacity .5s, z-index .5s;
 
   @media (max-width: ${Theme.breakpoints.xl}) {
     position: fixed;


### PR DESCRIPTION
Hi Kevin,

Thanks for sharing this excellent Gatsby theme!  I looked through the entire Gatsby theme showcase, and the features and aesthetic of your theme made it my favorite.

I noticed an issue with the Table of Contents feature on mobile screen widths.  For example, if you view [the Features post](https://nehalem.netlify.com/features) on a narrow screen (so the Table of Contents icon floats in the lower-right corner), you'll see that you can't click links or highlight text on the page.  The full-screen Left Sidebar is the target of all the mouse interactions even though it has `opacity: 0`.

When I decrease the `z-index` of the hidden sidebar, everything seems to work well including Table of Contents' the fade-in / fade-out animation.